### PR TITLE
color changes and hacks

### DIFF
--- a/content/blog/other/potw.md
+++ b/content/blog/other/potw.md
@@ -3,6 +3,8 @@ title: Playlist of the week
 author: Mathias Bøe
 tags: playlist, week
 date: 2020-09-30
+color: "#1DB954"
+important: true
 ---
 
 If you only want the current playlist without going through the different weeks, you can find it here: [https://open.spotify.com/playlist/7ko2hTDcHjbxdAP16r7W2T?si=Q0La5FFXTIalepDc4ox9sw](https://open.spotify.com/playlist/7ko2hTDcHjbxdAP16r7W2T?si=Q0La5FFXTIalepDc4ox9sw).

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -47,6 +47,7 @@ interface Props {
   other?: boolean;
   notes?: boolean;
   tags?: boolean;
+  color?: string;
 }
 
 type StyledProps = Omit<Props, "delay">;
@@ -61,9 +62,10 @@ const StyledCard = styled.div<StyledProps>`
     margin-bottom: 12px;
 		box-shadow: 0 5px 10px -5px rgba(0, 0, 0, 1);
     background-color: #F1F1F1;
+		${(props) => props.important && important}
+    background-color: ${props => props.color ? props.color : null};
     ${(props) => props.animated && animatedCss}
 		${(props) => props.primary && primaryCss}
-		${(props) => props.important && important}
 		${(props) => props.news && newsCss}
 		${(props) => props.other && otherCss}
     ${(props) => props.notes && notesCss}
@@ -80,6 +82,7 @@ const Card: React.FC<Props> = ({
   noMargin,
   big,
   tags,
+  color,
   children,
 }) => {
   return (
@@ -93,6 +96,7 @@ const Card: React.FC<Props> = ({
       big={big}
       noMargin={noMargin}
       tags={tags}
+      color={color}
     >
       {children}
     </StyledCard>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -46,6 +46,7 @@ const BlogIndex: React.FC<Props> = ({ location }) => {
                 description
                 tags
                 important
+                color
               }
             }
           }
@@ -64,8 +65,9 @@ const BlogIndex: React.FC<Props> = ({ location }) => {
         const title = node.frontmatter.title || node.fields.slug;
         const tags = node.frontmatter.tags;
         const important = node.frontmatter.important;
+        const colorCss = node.frontmatter.color;
         return (
-          <Card important={important} big>
+          <Card important={important} color={colorCss} big>
             <article key={node.fields.slug}>
               <small>{node.frontmatter.date}</small>
               {tags && tags.length > 0 ? ` - ` : ``}


### PR DESCRIPTION
This is a pure hack, its horribly put together because I don't have time to do it properly, but it lays the foundation for someone else to make it better.

In the cards component making a calculation based on the color passed in and from there making the text white/black would be the best solution. But we currently have a bad card component, see issue #22 .

I want this functionality on the page, but do not have time to implement it properly as of now.

As it works now, if you want to have white text on a colored background, you will have to pass in both the important flag AND the color flag. That way it uses the styling for important, and the background-color change from color.

It's a workaround and a hack, someone please pull this branch and fix the issues if you have the time.