### PR TITLE
updating nav menu links to be expected semantics

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -27,9 +27,11 @@ const Layout: React.FC<Props> = ({ location, title, children }) => {
     header = <StyledHeader />;
   } else {
     header = (
-      <h3
+      <div
         style={{
           fontFamily: `Roboto, sans-serif`,
+          textTransform: `uppercase`,
+          fontWeight: 700,
           marginTop: 0,
         }}
       >
@@ -42,7 +44,7 @@ const Layout: React.FC<Props> = ({ location, title, children }) => {
         >
           Back to home
         </Link>
-      </h3>
+      </div>
     );
   }
   return (

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -1,8 +1,7 @@
 import React from "react";
 import styled from "styled-components";
-import { Link } from "gatsby";
 
-const StyledNav = styled.div`
+const StyledNav = styled.nav`
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
@@ -15,27 +14,32 @@ const StyledNav = styled.div`
   z-index: 10;
 `;
 
-const StyledH1 = styled.h1`
+const StyledLink = styled.a.attrs(props => {
+  href: props.href
+})`
   margin-top: 24px;
   margin-bottom: 24px;
   font-size: 14pt;
+  font-weight: 700;
+  font-family: 'Roboto Slab',sans-serif;
+  text-transform: uppercase;
 `;
 
 export default function Nav() {
   return (
     <StyledNav>
-      <Link to="/">
-        <StyledH1>HOME</StyledH1>
-      </Link>
-      <Link to="/notes/">
-        <StyledH1>NOTES</StyledH1>
-      </Link>
-      <Link to="/info/">
-        <StyledH1>INFO</StyledH1>
-      </Link>
-      <Link to="/other/">
-        <StyledH1>OTHER</StyledH1>
-      </Link>
+      <StyledLink href="/">
+        Home
+      </StyledLink>
+      <StyledLink href="/notes/">
+        Notes
+      </StyledLink>
+      <StyledLink href="/info/">
+        Info
+      </StyledLink>
+      <StyledLink href="/other/">
+        Other
+      </StyledLink>
     </StyledNav>
   );
 }


### PR DESCRIPTION
Updating heading usage in navigation. 


From MDN.
```
Avoid using heading tags to resize text. Instead, use the CSS font-size property. Headings use size to indicate their relative importance, but CSS is preferred for general-purpose resizing.

Avoid skipping heading levels: always start from <h1>, next use <h2> and so on.

You should only use one <h1> per page. Using more than one will not result in an error, but using only one is seen as a best practice. It makes logical sense — <h1> is the most important heading, and tells you what the purpose of the overall page is. You wouldn't have a book with more than one title, or a movie with more than one name! Having a single top-level title is also arguably better for screenreader users, and SEO.
```