### PR TITLE
Author credits

### DIFF
--- a/content/blog/notes/DAT103.md
+++ b/content/blog/notes/DAT103.md
@@ -3,6 +3,7 @@ title: DAT103 notes
 description: Converted old Norwegian notes on DAT103
 date: 2019-03-02
 tags: dat103, notes
+author: Mathias Bøe
 ---
 
 Info om notat. Når du ser tekst i source blokker

--- a/content/blog/notes/INF142.md
+++ b/content/blog/notes/INF142.md
@@ -3,6 +3,7 @@ title: INF142 notes - Eksamensforberedelse
 description: Converted old Norwegian notes on INF142
 date: 2019-03-02
 tags: INF142, notes
+author: Mathias Bøe
 ---
 
 ## Eksamen vår 2016

--- a/content/blog/notes/INF143.mdx
+++ b/content/blog/notes/INF143.mdx
@@ -3,6 +3,7 @@ title: INF143 notes
 date: "2020-05-01T22:12:03.284Z"
 description: "Norwegian notes on INF143"
 tags: notes, inf143
+author: Mathias Bøe
 ---
 
 ## Nettbank

--- a/content/blog/notes/INF214.md
+++ b/content/blog/notes/INF214.md
@@ -3,6 +3,7 @@ title: INF214 notes - Concurrent Programming
 description: Notes on INF214
 date: 2020-11-20
 tags: inf214, notes
+author: Marie Heggebakk
 ---
 
 # The Concurrent Computing Landscape

--- a/content/blog/notes/INF226.md
+++ b/content/blog/notes/INF226.md
@@ -3,6 +3,7 @@ title: INF226 notes - Software Security
 description: Converted old Norwegian notes on INF226
 date: 2019-03-02
 tags: inf226, notes
+author: Mathias Bøe
 ---
 
 ## Learning goals

--- a/content/blog/notes/INF251.md
+++ b/content/blog/notes/INF251.md
@@ -3,6 +3,7 @@ title: INF251 notes
 date: "2020-11-23T22:15:00.000Z"
 description: "Notes on INF251"
 tags: notes, inf251
+author: Anders Syvertsen
 ---
 
 _A bunch of random notes from INF251 sorted by lectures. **Computer Graphics Pipeline Overview** and **Splines** should be partially structured and readable, the rest are less so._

--- a/content/blog/notes/inf102.md
+++ b/content/blog/notes/inf102.md
@@ -3,6 +3,7 @@ title: INF102 notes
 description: SHITTY Converted old Norwegian notes on inf102
 date: 2019-03-01
 tags: inf102, notes
+author: Mathias Bøe
 ---
 
 **BIG DISCLAIMER**

--- a/src/templates/blog-post.tsx
+++ b/src/templates/blog-post.tsx
@@ -65,6 +65,7 @@ interface Props {
         title: string;
         date: string;
         description: string;
+        author: string;
       };
     };
   };
@@ -105,15 +106,29 @@ const BlogPostTemplate: React.FC<Props> = ({ data, pageContext, location }) => {
           >
             {post.frontmatter.title}
           </h1>
-          <p
+          <div
             style={{
               ...scale(-1 / 5),
               display: `block`,
               marginBottom: rhythm(1),
             }}
           >
-            {post.frontmatter.date}
-          </p>
+            <p
+              style={{
+                float: "left",
+              }}
+            >
+              {post.frontmatter.date}
+            </p>
+            <p
+              style={{
+                float: "right",
+              }}
+            >
+              {post.frontmatter.author}
+            </p>
+          </div>
+          <div style={{ clear: "both" }}></div>
         </header>
         <MDXRenderer>{post.body}</MDXRenderer>
         <hr
@@ -169,6 +184,7 @@ export const pageQuery = graphql`
         title
         date(formatString: "MMMM DD, YYYY")
         description
+        author
       }
     }
   }


### PR DESCRIPTION
Authors are credited from optional "author" metadata in markdown file. Author name is displayed in the same format as date, aligned to the right.
Any feedback?

This closes #36 